### PR TITLE
[WIP] Fix API so that it returns associated objects too

### DIFF
--- a/src/api/components.js
+++ b/src/api/components.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var ComponentService = Services.ComponentService;
 
@@ -44,26 +44,14 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Component = new ComponentService(params);
-
     Component
         .find()
         .then(function(result) {
@@ -77,22 +65,11 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Component = new ComponentService(params);
-
     Component
         .findAll()
         .then(function(result) {

--- a/src/api/configGroups.js
+++ b/src/api/configGroups.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var ConfigGroupService = Services.ConfigGroupService;
 
@@ -44,24 +44,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var ConfigGroup = new ConfigGroupService(params);
 
     ConfigGroup
@@ -77,20 +66,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var ConfigGroup = new ConfigGroupService(params);
 
     ConfigGroup

--- a/src/api/configTypes.js
+++ b/src/api/configTypes.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var ConfigTypeService = Services.ConfigTypeService;
 
@@ -44,24 +44,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var ConfigType = new ConfigTypeService(params);
 
     ConfigType
@@ -77,20 +66,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var ConfigType = new ConfigTypeService(params);
 
     ConfigType

--- a/src/api/configs.js
+++ b/src/api/configs.js
@@ -3,6 +3,7 @@
 
 // ---------------------- Dependencies ---->>
 
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var ConfigService = Services.ConfigService;
 
@@ -44,24 +45,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Config = new ConfigService(params);
 
     Config
@@ -77,20 +67,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Config = new ConfigService(params);
 
     Config

--- a/src/api/connections.js
+++ b/src/api/connections.js
@@ -3,6 +3,7 @@
 
 // ---------------------- Dependencies ---->>
 
+const _ = require('lodash');
 var Services = require('../services/index.js');
 var ConnectionService = Services.ConnectionService;
 
@@ -50,7 +51,7 @@ exports.find = function(req, res) {
   var params = {};
 
   Model = require('../models/index.js');
-  Models = new Model();
+  Models = new Model().models;
 
   params.where = {id: req.params.id};
 
@@ -60,7 +61,6 @@ exports.find = function(req, res) {
       var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
       includes.push(Models[capitalize]);
     }
-
     params.include = includes;
   }
 
@@ -79,19 +79,36 @@ exports.find = function(req, res) {
 
 exports.findAll = function(req, res) {
   var Model = require('../models/index.js');
-  var Models = new Model();
+  var Models = new Model().models;
   var includes = [];
   var params = {};
 
   // ie: ?include=category&include=file&include=image
+  console.log("Req.query.include: ", req.query.include);
+  if (req.query.include) {
+    var include = req.query.include;
+    if (_.isArray(include)) {
+      includes = _.clone(req.query.include);
+    } else {
+      includes.push(include);
+    }
+    includes = _.map(includes, (include) => {
+      return {
+        model: Models[_.capitalize(include)]
+      };
+    });
+    params.include = includes;
+  }
+  /*
   if (req.query.include) {
     for (var i = 0; i < req.query.include.length; i++) {
       var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
       includes.push(Models[capitalize]);
     }
-
     params.include = includes;
   }
+  */
+  console.log("Params: ", params);
 
   var Connection = new ConnectionService(params);
 

--- a/src/api/connections.js
+++ b/src/api/connections.js
@@ -2,8 +2,9 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
 const _ = require('lodash');
+const Helpers = require('./helpers.js');
+
 var Services = require('../services/index.js');
 var ConnectionService = Services.ConnectionService;
 
@@ -47,25 +48,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function(req, res) {
-  var Model, Models;
-  var params = {};
-
-  Model = require('../models/index.js');
-  Models = new Model().models;
-
+  const Model = require('../models/index.js');
+  const models = new Model().models;
+  const params = {};
   params.where = {id: req.params.id};
-
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var Connection = new ConnectionService(params);
-
   Connection
     .find()
     .then(function(result) {
@@ -79,39 +68,11 @@ exports.find = function(req, res) {
 
 exports.findAll = function(req, res) {
   var Model = require('../models/index.js');
-  var Models = new Model().models;
-  var includes = [];
+  const models = new Model().models;
   var params = {};
-
   // ie: ?include=category&include=file&include=image
-  console.log("Req.query.include: ", req.query.include);
-  if (req.query.include) {
-    var include = req.query.include;
-    if (_.isArray(include)) {
-      includes = _.clone(req.query.include);
-    } else {
-      includes.push(include);
-    }
-    includes = _.map(includes, (include) => {
-      return {
-        model: Models[_.capitalize(include)]
-      };
-    });
-    params.include = includes;
-  }
-  /*
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-    params.include = includes;
-  }
-  */
-  console.log("Params: ", params);
-
+  Helpers.applyModelIncludes(params, req, models);
   var Connection = new ConnectionService(params);
-
   Connection
     .findAll()
     .then(function(result) {

--- a/src/api/environments.js
+++ b/src/api/environments.js
@@ -3,6 +3,7 @@
 
 // ---------------------- Dependencies ---->>
 
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var EnvironmentService = Services.EnvironmentService;
 
@@ -44,24 +45,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Environment = new EnvironmentService(params);
 
     Environment
@@ -77,20 +67,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Environment = new EnvironmentService(params);
 
     Environment

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -13,10 +13,19 @@ exports.applyModelIncludes = function(params, req, models) {
     } else {
       includes.push(include);
     }
-    includes = _.map(includes, (include) => {
-      return {
-        model: models[_.capitalize(include)]
-      };
+    includes = _.filter(_.map(includes, (include) => {
+      // Do our best to normalize the requested model name
+      const name = _.upperFirst(_.camelCase(include));
+      if (name in models) {
+        return {
+          model: models[name]
+        };
+      } else {
+        console.log("Unknown model: ", name);
+        return undefined;
+      }
+    }), function(include) {
+      return include !== undefined;
     });
     params.include = includes;
   }

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// ---------------------- Dependencies ---->>
+const _ = require('lodash');
+
+exports.applyModelIncludes = function(params, req, models) {
+  var includes = [];
+  // ie: ?include=category&include=file&include=image
+  if (req.query.include) {
+    var include = req.query.include;
+    if (_.isArray(include)) {
+      includes = _.clone(req.query.include);
+    } else {
+      includes.push(include);
+    }
+    includes = _.map(includes, (include) => {
+      return {
+        model: models[_.capitalize(include)]
+      };
+    });
+    params.include = includes;
+  }
+
+}

--- a/src/api/integrationPatterns.js
+++ b/src/api/integrationPatterns.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var IntegrationPatternService = Services.IntegrationPatternService;
 
@@ -46,27 +46,16 @@ exports.del = function(req, res) {
 
 
 exports.find = function(req, res) {
-  var Model, Models;
-  var params = {};
+    var Model, models;
+    Model = require('../models/index.js');
+    models = new Model().models;
+    var params = {};
+    params.where = { id: req.params.id };
+    // ie: ?include=category&include=file&include=image
+    Helpers.applyModelIncludes(params, req, models);
+    var IntegrationPattern = new IntegrationPatternService(params);
 
-  Model = require('../models/index.js');
-  Models = new Model();
-
-  params.where = {id: req.params.id};
-
-  // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
-  var IntegrationPattern = new IntegrationPatternService(params);
-
-  IntegrationPattern
+    IntegrationPattern
     .find()
     .then(function(result) {
       res.json(result);
@@ -78,31 +67,21 @@ exports.find = function(req, res) {
 
 
 exports.findAll = function(req, res) {
-  var Model = require('../models/index.js');
-  var Models = new Model();
-  var includes = [];
-  var params = {};
+    var Model = require('../models/index.js');
+    var models = new Model().models;
+    var params = {};
+    // ie: ?include=category&include=file&include=image
+    Helpers.applyModelIncludes(params, req, models);
+    var IntegrationPattern = new IntegrationPatternService(params);
 
-  // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
-  var IntegrationPattern = new IntegrationPatternService(params);
-
-  IntegrationPattern
-    .findAll()
-    .then(function(result) {
-      res.json(result);
-    })
-    .catch(function(err) {
-      res.json(err);
-    });
+    IntegrationPattern
+      .findAll()
+      .then(function(result) {
+        res.json(result);
+      })
+      .catch(function(err) {
+        res.json(err);
+      });
 };
 
 exports.save = function(req, res) {

--- a/src/api/integrationTemplates.js
+++ b/src/api/integrationTemplates.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var IntegrationTemplateService = Services.IntegrationTemplateService;
 
@@ -44,26 +44,14 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var IntegrationTemplate = new IntegrationTemplateService(params);
-
     IntegrationTemplate
         .find()
         .then(function(result) {
@@ -77,22 +65,11 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var IntegrationTemplate = new IntegrationTemplateService(params);
-
     IntegrationTemplate
         .findAll()
         .then(function(result) {

--- a/src/api/integrations.js
+++ b/src/api/integrations.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var IntegrationService = Services.IntegrationService;
 
@@ -44,24 +44,12 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
-    // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Integration = new IntegrationService(params);
 
     Integration
@@ -77,22 +65,11 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Integration = new IntegrationService(params);
-
     Integration
         .findAll()
         .then(function(result) {

--- a/src/api/organizations.js
+++ b/src/api/organizations.js
@@ -3,6 +3,7 @@
 
 // ---------------------- Dependencies ---->>
 
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var OrganizationService = Services.OrganizationService;
 
@@ -44,24 +45,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Organization = new OrganizationService(params);
 
     Organization
@@ -77,20 +67,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Organization = new OrganizationService(params);
 
     Organization

--- a/src/api/permissions.js
+++ b/src/api/permissions.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var PermissionService = Services.PermissionService;
 
@@ -46,24 +46,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function(req, res) {
-  var Model, Models;
-  var params = {};
-
+  var Model, models;
   Model = require('../models/index.js');
-  Models = new Model();
-
-  params.where = {id: req.params.id};
-
+  models = new Model().models;
+  var params = {};
+  params.where = { id: req.params.id };
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var Permission = new PermissionService(params);
 
   Permission
@@ -79,20 +68,10 @@ exports.find = function(req, res) {
 
 exports.findAll = function(req, res) {
   var Model = require('../models/index.js');
-  var Models = new Model();
-  var includes = [];
+  var models = new Model().models;
   var params = {};
-
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var Permission = new PermissionService(params);
 
   Permission

--- a/src/api/roles.js
+++ b/src/api/roles.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var UserService = Services.UserService;
 var RoleService = Services.RoleService;
@@ -47,24 +47,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function(req, res) {
-  var Model, Models;
-  var params = {};
-
+  var Model, models;
   Model = require('../models/index.js');
-  Models = new Model();
-
-  params.where = {id: req.params.id};
-
+  models = new Model().models;
+  var params = {};
+  params.where = { id: req.params.id };
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var Role = new RoleService(params);
 
   Role
@@ -80,20 +69,10 @@ exports.find = function(req, res) {
 
 exports.findAll = function(req, res) {
   var Model = require('../models/index.js');
-  var Models = new Model();
-  var includes = [];
+  var models = new Model().models;
   var params = {};
-
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var Role = new RoleService(params);
 
   Role

--- a/src/api/steps.js
+++ b/src/api/steps.js
@@ -3,6 +3,7 @@
 
 // ---------------------- Dependencies ---->>
 
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var StepService = Services.StepService;
 
@@ -44,24 +45,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Step = new StepService(params);
 
     Step
@@ -77,20 +67,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Step = new StepService(params);
 
     Step

--- a/src/api/tags.js
+++ b/src/api/tags.js
@@ -3,6 +3,7 @@
 
 // ---------------------- Dependencies ---->>
 
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var TagService = Services.TagService;
 
@@ -44,24 +45,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function (req, res) {
-    var Model, Models;
-    var params = {};
-
+    var Model, models;
     Model = require('../models/index.js');
-    Models = new Model();
-
+    models = new Model().models;
+    var params = {};
     params.where = { id: req.params.id };
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Tag = new TagService(params);
 
     Tag
@@ -77,20 +67,10 @@ exports.find = function (req, res) {
 
 exports.findAll = function (req, res) {
     var Model = require('../models/index.js');
-    var Models = new Model();
-    var includes = [];
+    var models = new Model().models;
     var params = {};
-
     // ie: ?include=category&include=file&include=image
-    if(req.query.include) {
-        for(var i = 0; i < req.query.include.length; i++) {
-            var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-            includes.push(Models[capitalize]);
-        }
-
-        params.include = includes;
-    }
-
+    Helpers.applyModelIncludes(params, req, models);
     var Tag = new TagService(params);
 
     Tag

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // ---------------------- Dependencies ---->>
-
+const Helpers = require('./helpers.js');
 var Services = require('../services/index.js');
 var UserService = Services.UserService;
 
@@ -46,24 +46,13 @@ exports.del = function(req, res) {
 
 
 exports.find = function(req, res) {
-  var Model, Models;
-  var params = {};
-
+  var Model, models;
   Model = require('../models/index.js');
-  Models = new Model();
-
-  params.where = {id: req.params.id};
-
+  models = new Model().models;
+  var params = {};
+  params.where = { id: req.params.id };
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var User = new UserService(params);
 
   User
@@ -79,20 +68,10 @@ exports.find = function(req, res) {
 
 exports.findAll = function(req, res) {
   var Model = require('../models/index.js');
-  var Models = new Model();
-  var includes = [];
+  var models = new Model().models;
   var params = {};
-
   // ie: ?include=category&include=file&include=image
-  if (req.query.include) {
-    for (var i = 0; i < req.query.include.length; i++) {
-      var capitalize = req.query.include[i][0].toUpperCase() + req.query.include[i].slice(1);
-      includes.push(Models[capitalize]);
-    }
-
-    params.include = includes;
-  }
-
+  Helpers.applyModelIncludes(params, req, models);
   var User = new UserService(params);
 
   User


### PR DESCRIPTION
My bad, I changed models/index.js as it was originally returning an empty db object, now it returns an object with the sequelize instance + the models in a 'models' attribute.

Am going to extract out the bit checking the 'include' URL parameters into a re-usable helper function, that's gonna be used for all objects, so makes sense to make it generic.

@kahboom FYI